### PR TITLE
Update proxy-wasm-cpp-sdk SHA and doc about SHA updating.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "proxy_wasm_cpp_sdk",
-    sha256 = "5909993d801690ff29cc2354a36d4939d8d2b8db0cf4f331057b079b49e4863f",
-    strip_prefix = "proxy-wasm-cpp-sdk-8564f6660d0fdadc55fc55a4b894bb1abd283c6c",
-    url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/8564f6660d0fdadc55fc55a4b894bb1abd283c6c.tar.gz",
+    sha256 = "0f675ef5c4f8fdcf2fce8152868c6c6fd33251a0deb4a8fc1ef721f9ed387dbc",
+    strip_prefix = "proxy-wasm-cpp-sdk-f5ecda129d1e45de36cb7898641ac225a50ce7f0",
+    url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/f5ecda129d1e45de36cb7898641ac225a50ce7f0.tar.gz",
 )
 
 load("@proxy_wasm_cpp_sdk//bazel/dep:deps.bzl", "wasm_dependencies")

--- a/doc/write-a-wasm-extension-with-cpp.md
+++ b/doc/write-a-wasm-extension-with-cpp.md
@@ -13,11 +13,11 @@ workspace(name = "example_extension")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# Pulls proxy wasm cpp SDK with a specific SHA
+# Pulls proxy wasm cpp SDK with a specific SHA. Here the SHA is set to the same as istio/envoy 1.8 branch
 http_archive(
     name = "proxy_wasm_cpp_sdk",
-    strip_prefix = "proxy-wasm-cpp-sdk-2ccab8dfc0b435f3d7641cef7683c7861e23d179",
-    url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/2ccab8dfc0b435f3d7641cef7683c7861e23d179.tar.gz",
+    strip_prefix = "proxy-wasm-cpp-sdk-f5ecda129d1e45de36cb7898641ac225a50ce7f0",
+    url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/f5ecda129d1e45de36cb7898641ac225a50ce7f0.tar.gz",
 )
 
 load("@proxy_wasm_cpp_sdk//bazel/dep:deps.bzl", "wasm_dependencies")
@@ -29,7 +29,7 @@ load("@proxy_wasm_cpp_sdk//bazel/dep:deps_extra.bzl", "wasm_dependencies_extra")
 wasm_dependencies_extra()
 ```
 
-You can rename the workspace to anything relevent to your extension. Other dependencies could also be imported as needed, such as JSON library, base64 library, etc. See the top level `WORKSPACE` file for examples.
+Currently, it is recommanded to update SHA of Wasm C++ SDK and build your extension following Istio releases. See [step 7](#step-7-maintain-your-extension-along-with-istio-releases) for more details on extension maintainance. (TODO: https://github.com/istio-ecosystem/wasm-extensions/issues/27) You can rename the workspace to anything relevent to your extension. Other dependencies could also be imported as needed, such as JSON library, base64 library, etc. See the [top level `WORKSPACE` file](../WORKSPACE) for examples.
 
 ## Step 2: Set up extension scaffold
 ---

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -5,9 +5,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Pulls proxy wasm cpp SDK with a specific SHA
 http_archive(
     name = "proxy_wasm_cpp_sdk",
-    sha256 = "5909993d801690ff29cc2354a36d4939d8d2b8db0cf4f331057b079b49e4863f",
-    strip_prefix = "proxy-wasm-cpp-sdk-8564f6660d0fdadc55fc55a4b894bb1abd283c6c",
-    url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/8564f6660d0fdadc55fc55a4b894bb1abd283c6c.tar.gz",
+    sha256 = "0f675ef5c4f8fdcf2fce8152868c6c6fd33251a0deb4a8fc1ef721f9ed387dbc",
+    strip_prefix = "proxy-wasm-cpp-sdk-f5ecda129d1e45de36cb7898641ac225a50ce7f0",
+    url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/f5ecda129d1e45de36cb7898641ac225a50ce7f0.tar.gz",
 )
 
 load("@proxy_wasm_cpp_sdk//bazel/dep:deps.bzl", "wasm_dependencies")


### PR DESCRIPTION
This updates SHA to the HEAD of istio-1.8 branch of proxy-wasm-cpp-sdk: https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/tree/istio-release/v1.8

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>