### PR TITLE
Add script for dep SHA update.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,11 +2,14 @@ workspace(name = "istio_ecosystem_wasm_extensions")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+PROXY_WASM_CPP_SDK_SHA = "f5ecda129d1e45de36cb7898641ac225a50ce7f0"
+PROXY_WASM_CPP_SDK_SHA256 = "0f675ef5c4f8fdcf2fce8152868c6c6fd33251a0deb4a8fc1ef721f9ed387dbc"
+
 http_archive(
     name = "proxy_wasm_cpp_sdk",
-    sha256 = "0f675ef5c4f8fdcf2fce8152868c6c6fd33251a0deb4a8fc1ef721f9ed387dbc",
-    strip_prefix = "proxy-wasm-cpp-sdk-f5ecda129d1e45de36cb7898641ac225a50ce7f0",
-    url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/f5ecda129d1e45de36cb7898641ac225a50ce7f0.tar.gz",
+    sha256 = PROXY_WASM_CPP_SDK_SHA256,
+    strip_prefix = "proxy-wasm-cpp-sdk-" + PROXY_WASM_CPP_SDK_SHA,
+    url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/" + PROXY_WASM_CPP_SDK_SHA + ".tar.gz",
 )
 
 load("@proxy_wasm_cpp_sdk//bazel/dep:deps.bzl", "wasm_dependencies")
@@ -19,11 +22,14 @@ wasm_dependencies_extra()
 
 ### optional imports ###
 # To import commonly used libraries from istio proxy, such as base64, json, and flatbuffer.
+IO_ISTIO_PROXY_SHA = "26f79858b782b1590bd482f060cda77e3b4d565c"
+IO_ISTIO_PROXY_SHA256 = "d41a8f33d1842cb56d9eb1f79c0a7c73abe52dac8a90bda51f365a8411495398"
+
 http_archive(
     name = "io_istio_proxy",
-    sha256 = "d41a8f33d1842cb56d9eb1f79c0a7c73abe52dac8a90bda51f365a8411495398",
-    strip_prefix = "proxy-26f79858b782b1590bd482f060cda77e3b4d565c",
-    url = "https://github.com/istio/proxy/archive/26f79858b782b1590bd482f060cda77e3b4d565c.tar.gz",
+    sha256 = IO_ISTIO_PROXY_SHA256,
+    strip_prefix = "proxy-" + IO_ISTIO_PROXY_SHA,
+    url = "https://github.com/istio/proxy/archive/" + IO_ISTIO_PROXY_SHA + ".tar.gz",
 )
 
 load("@istio_ecosystem_wasm_extensions//bazel:wasm.bzl", "wasm_libraries")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,8 +22,8 @@ wasm_dependencies_extra()
 
 ### optional imports ###
 # To import commonly used libraries from istio proxy, such as base64, json, and flatbuffer.
-IO_ISTIO_PROXY_SHA = "26f79858b782b1590bd482f060cda77e3b4d565c"
-IO_ISTIO_PROXY_SHA256 = "d41a8f33d1842cb56d9eb1f79c0a7c73abe52dac8a90bda51f365a8411495398"
+IO_ISTIO_PROXY_SHA = "aaff48d79dc578e4e6ef8525f96734b972a7670f"
+IO_ISTIO_PROXY_SHA256 = "25825a882bad81495e74db2a839301a018631f8af09bfbb82923d5a067c66036"
 
 http_archive(
     name = "io_istio_proxy",

--- a/bazel/wasm.bzl
+++ b/bazel/wasm.bzl
@@ -20,17 +20,22 @@ def wasm_libraries():
         urls = ["https://github.com/google/googletest/archive/release-1.10.0.tar.gz"],
     )
 
+    PROXY_WASM_CPP_HOST_SHA = "a044a3a5bec75ce57c12d9e2b0e95e2a14f9f944"
+    PROXY_WASM_CPP_HOST_SHA256 = "619e61997682931e07e92f5b64a4268715598d3aa22a41cadeeca816103d731f"
+    BORINGSSL_SHA = "2192bbc878822cf6ab5977d4257a1339453d9d39"
+    BORINGSSL_SHA256 = "bb55b0ed2f0cb548b5dce6a6b8307ce37f7f748eb9f1be6bfe2d266ff2b4d52b"
+
     http_archive(
         name = "proxy_wasm_cpp_host",
-        sha256 = "619e61997682931e07e92f5b64a4268715598d3aa22a41cadeeca816103d731f",
-        strip_prefix = "proxy-wasm-cpp-host-a044a3a5bec75ce57c12d9e2b0e95e2a14f9f944",
-        url = "https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/a044a3a5bec75ce57c12d9e2b0e95e2a14f9f944.tar.gz",
+        sha256 = PROXY_WASM_CPP_HOST_SHA256,
+        strip_prefix = "proxy-wasm-cpp-host-" + PROXY_WASM_CPP_HOST_SHA,
+        url = "https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/" + PROXY_WASM_CPP_HOST_SHA +".tar.gz",
     )
 
     # needed by proxy wasm cpp host
     http_archive(
         name = "boringssl",
-        sha256 = "bb55b0ed2f0cb548b5dce6a6b8307ce37f7f748eb9f1be6bfe2d266ff2b4d52b",
-        strip_prefix = "boringssl-2192bbc878822cf6ab5977d4257a1339453d9d39",
-        urls = ["https://github.com/google/boringssl/archive/2192bbc878822cf6ab5977d4257a1339453d9d39.tar.gz"],
+        sha256 = BORINGSSL_SHA256,
+        strip_prefix = "boringssl-" + BORINGSSL_SHA,
+        urls = ["https://github.com/google/boringssl/archive/" + BORINGSSL_SHA + ".tar.gz"],
     )

--- a/scripts/update-dep.sh
+++ b/scripts/update-dep.sh
@@ -31,13 +31,11 @@ trap "rm -rf ${ENVOY_TMP_DIR}" EXIT
 
 cd ${ENVOY_TMP_DIR}
 if [[ ${RELEASE} == "master" ]]; then
-  git clone https://github.com/envoyproxy/envoy
-  cd envoy
+  git clone --depth=1 --branch master https://github.com/envoyproxy/envoy
 else
-  git clone https://github.com/istio/envoy
-  cd envoy
-  git checkout release-${RELEASE}
+  git clone --depth=1 --branch release-${RELEASE} https://github.com/istio/envoy
 fi
+cd envoy
 
 # SDK SHA update
 NEW_SDK_SHA=$(bazel query //external:proxy_wasm_cpp_sdk --output=build | grep -Pom1 "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/\K[a-zA-Z0-9]{40}")
@@ -65,11 +63,12 @@ trap "rm -rf ${ISTIO_PROXY_TMP_DIR}" EXIT
 
 cd ${ISTIO_PROXY_TMP_DIR}
 
-git clone https://github.com/istio/proxy
-cd proxy
-if [[ ${RELEASE} != "master" ]]; then
-  git checkout release-${RELEASE}
+if [[ ${RELEASE} == "master" ]]; then
+  git clone --depth=1 --branch master https://github.com/istio/proxy
+else
+  git clone --depth=1 --branch release-${RELEASE} https://github.com/istio/proxy
 fi
+cd proxy
 
 NEW_PROXY_SHA=$(git rev-parse HEAD)
 NEW_PROXY_SHA256=$(wget https://github.com/istio/proxy/archive/${NEW_PROXY_SHA}.tar.gz && sha256sum ${NEW_PROXY_SHA}.tar.gz | grep -Pom1 "\K[a-zA-Z0-9]{64}")

--- a/scripts/update-dep.sh
+++ b/scripts/update-dep.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -eu
+
+# update proxy-wasm-cpp-sdk, proxy-wasm-cpp-host, and istio-proxy SHA based on the given branch
+function usage() {
+  echo "$0
+    -r the release branch that this script should look at, e.g. 1.8, master."
+  exit 1
+}
+
+RELEASE=""
+
+while getopts r: arg ; do
+  case "${arg}" in
+    r) RELEASE="${OPTARG}";;
+    *) usage;;
+  esac
+done
+
+if [[ ${RELEASE} == "" ]]; then
+    echo "release branch has to be provided. e.g. update-dep.sh -r 1.8"
+    exit 1
+fi
+
+WD=$(pwd)
+
+# Clone istio-envoy repo, get and update proxy Wasm sdk and host SHA
+ENVOY_TMP_DIR=$(mktemp -d -t envoy-XXXXXXXXXX)
+trap "rm -rf ${ENVOY_TMP_DIR}" EXIT
+
+cd ${ENVOY_TMP_DIR}
+if [[ ${RELEASE} == "master" ]]; then
+  git clone https://github.com/envoyproxy/envoy
+  cd envoy
+else
+  git clone https://github.com/istio/envoy
+  cd envoy
+  git checkout release-${RELEASE}
+fi
+
+# SDK SHA update
+NEW_SDK_SHA=$(bazel query //external:proxy_wasm_cpp_sdk --output=build | grep -Pom1 "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/\K[a-zA-Z0-9]{40}")
+NEW_SDK_SHA256=$(bazel query //external:proxy_wasm_cpp_sdk --output=build | grep -Pom1 "sha256 = \"\K[a-zA-Z0-9]{64}")
+pushd $WD
+CUR_SDK_SHA=$(bazel query //external:proxy_wasm_cpp_sdk --output=build | grep -Pom1 "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/\K[a-zA-Z0-9]{40}")
+CUR_SDK_SHA256=$(bazel query //external:proxy_wasm_cpp_sdk --output=build | grep -Pom1 "sha256 = \"\K[a-zA-Z0-9]{64}")
+sed -i "s/${CUR_SDK_SHA}/${NEW_SDK_SHA}/g" WORKSPACE
+sed -i "s/${CUR_SDK_SHA256}/${NEW_SDK_SHA256}/g" WORKSPACE
+popd
+
+# Host SHA update
+NEW_HOST_SHA=$(bazel query //external:proxy_wasm_cpp_host --output=build | grep -Pom1 "https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/\K[a-zA-Z0-9]{40}")
+NEW_HOST_SHA256=$(bazel query //external:proxy_wasm_cpp_host --output=build | grep -Pom1 "sha256 = \"\K[a-zA-Z0-9]{64}")
+pushd $WD
+CUR_HOST_SHA=$(bazel query //external:proxy_wasm_cpp_host --output=build | grep -Pom1 "https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/\K[a-zA-Z0-9]{40}")
+CUR_HOST_SHA256=$(bazel query //external:proxy_wasm_cpp_host --output=build | grep -Pom1 "sha256 = \"\K[a-zA-Z0-9]{64}")
+sed -i "s/${CUR_HOST_SHA}/${NEW_HOST_SHA}/g" bazel/wasm.bzl
+sed -i "s/${CUR_HOST_SHA256}/${NEW_HOST_SHA256}/g" bazel/wasm.bzl
+popd
+
+# Istio proxy SHA update
+ISTIO_PROXY_TMP_DIR=$(mktemp -d -t proxy-XXXXXXXXXX)
+trap "rm -rf ${ISTIO_PROXY_TMP_DIR}" EXIT
+
+cd ${ISTIO_PROXY_TMP_DIR}
+
+git clone https://github.com/istio/proxy
+cd proxy
+if [[ ${RELEASE} != "master" ]]; then
+  git checkout release-${RELEASE}
+fi
+
+NEW_PROXY_SHA=$(git rev-parse HEAD)
+NEW_PROXY_SHA256=$(wget https://github.com/istio/proxy/archive/${NEW_PROXY_SHA}.tar.gz && sha256sum ${NEW_PROXY_SHA}.tar.gz | grep -Pom1 "\K[a-zA-Z0-9]{64}")
+pushd $WD
+CUR_PROXY_SHA=$(bazel query //external:io_istio_proxy --output=build | grep -Pom1 "https://github.com/istio/proxy/archive/\K[a-zA-Z0-9]{40}")
+CUR_PROXY_SHA256=$(bazel query //external:io_istio_proxy --output=build | grep -Pom1 "sha256 = \"\K[a-zA-Z0-9]{64}")
+sed -i "s/${CUR_PROXY_SHA}/${NEW_PROXY_SHA}/g" WORKSPACE
+sed -i "s/${CUR_PROXY_SHA256}/${NEW_PROXY_SHA256}/g" WORKSPACE
+popd


### PR DESCRIPTION
This will simplify SHA update. For example, run `update-dep.sh -r 1.8` to update relevent SHA to be the same as Istio 1.8.

This change also updates SHA to match Istio 1.8, in prep for branch cut.