### PR TITLE
Add release workflow.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          export_default_credentials: true
+      - name: Download artifacts
+        run: |
+          COMMIT=$(git rev-list -n 1 ${{ github.ref }})
+          gsutil cp gs://istio-ecosystem/wasm-extensions/basic-auth/${COMMIT}.wasm basic-auth.wasm
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: ./basic-auth.wasm
+          asset_name: basic-auth.wasm
+          asset_content_type: application/wasm


### PR DESCRIPTION
This workflow is going to be triggered by any tag pushed. It will upload basic_auth wasm file for now. Github download path is versioned naturally based on tagging. For example `https://github.com/bianpengyuan/wasm-extensions/releases/download/1.8.0/basic-auth.wasm`.

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>