### PR TITLE
Upload release asset also upload to GCS.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,10 @@ jobs:
         run: |
           COMMIT=$(git rev-list -n 1 ${{ github.ref }})
           gsutil cp gs://istio-ecosystem/wasm-extensions/basic-auth/${COMMIT}.wasm basic-auth.wasm
+          # Also prepare an Wasm extension dir for GCS uploading.
+          mkdir -p wasm-extensions/basic-auth
+          GITHUB_TAG_REF=${{ github.ref }}
+          cp basic-auth.wasm wasm-extensions/basic-auth/${GITHUB_TAG_REF##*/}.wasm
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -40,3 +44,9 @@ jobs:
           asset_path: ./basic-auth.wasm
           asset_name: basic-auth.wasm
           asset_content_type: application/wasm
+      - name: Upload Modules
+        uses: GoogleCloudPlatform/github-actions/upload-cloud-storage@master
+        with:
+          path: wasm-extensions/
+          destination: istio-ecosystem
+          credentials: ${{ secrets.WASM_UPLOAD_CRED }}


### PR DESCRIPTION
Github asset downloading will result in a 302, which is not properly handled by Envoy remote load. This is to also upload the release artifacts to GCS since it could work with Envoy. The download URL will be like `https://storage.googleapis.com/istio-ecosystem/wasm-extensions/basic-auth/1.8.0.wasm`.

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>