### PR TITLE
Add doc for basic auth filter user guide.

### DIFF
--- a/extensions/basic_auth/README.md
+++ b/extensions/basic_auth/README.md
@@ -1,6 +1,8 @@
 # Basic Auth Filter User Guide
 
-> **Note**: This is an experimental feature and not recommended for production usage.
+> **Note**: This is an experimental feature.
+
+> **Note**: Basic Auth is not recommended for production usage since it is not secure enough. Please consider using Istio mTLS instead in production.
 
 Basic Auth filter is shipped as a WebAssembly filter from this repo. It is versioned following Istio minor release (e.g. basic auth Wasm module with version 1.8.x should work with any Istio 1.8 patch versions). All released versions could be found [here](https://github.com/istio-ecosystem/wasm-extensions/releases).
 

--- a/extensions/basic_auth/config/gateway-filter.yaml
+++ b/extensions/basic_auth/config/gateway-filter.yaml
@@ -1,0 +1,56 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: basic-auth-filter
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: example-filter
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                    "basic_auth_rules": [
+                      {
+                        "prefix": "/",
+                        "request_methods": ["GET", "POST"],
+                        "credentials": [
+                          "ok:test",
+                          "admin:admin",
+                          "admin2:admin2"
+                        ]
+                      }
+                    ]
+                  }
+              vm_config:
+                vm_id: basic_auth
+                code:
+                  remote:
+                    http_uri:
+                      uri: https://storage.googleapis.com/istio-ecosystem/wasm-extensions/basic-auth/1.8.0.wasm
+                      cluster: google-storage
+                      timeout: 10s
+                    sha256: 707e29db817f76c974d7ce1fe2f61ad64c88856c7ddba99a36fe95439bfe1281
+                    retry_policy:
+                      num_retries: 5
+                      retry_back_off:
+                        base_interval: 1s
+                        max_interval: 3s
+                runtime: envoy.wasm.runtime.v8

--- a/extensions/basic_auth/config/storage-cluster.yaml
+++ b/extensions/basic_auth/config/storage-cluster.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: google-storage
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: CLUSTER
+    patch:
+      operation: ADD
+      value:
+        name: google-storage
+        dns_lookup_family: V4_ONLY
+        type: STRICT_DNS
+        connect_timeout: 5s
+        transport_socket:
+          name: envoy.transport_sockets.tls
+        load_assignment:
+          cluster_name: google-storage
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: storage.googleapis.com
+                    port_value: 443


### PR DESCRIPTION
Update basic auth user guide based on remote load. https://github.com/bianpengyuan/wasm-extensions/tree/extension/basic-auth/extensions/basic_auth has a rendered version of this user guide.

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>