### PR TITLE
Remove null plugin mode from scaffold extension.

### DIFF
--- a/extensions/scaffold/BUILD
+++ b/extensions/scaffold/BUILD
@@ -10,17 +10,3 @@ wasm_cc_binary(
         "@proxy_wasm_cpp_sdk//:proxy_wasm_intrinsics",
     ],
 )
-
-cc_library(
-    name = "scaffold",
-    srcs = [
-        "plugin.cc",
-    ],
-    hdrs = [
-        "plugin.h",
-    ],
-    copts = ["-DNULL_PLUGIN"],
-    deps = [
-        "@proxy_wasm_cpp_host//:lib",
-    ],
-)

--- a/extensions/scaffold/plugin.cc
+++ b/extensions/scaffold/plugin.cc
@@ -1,24 +1,6 @@
 #include "extensions/scaffold/plugin.h"
 
-#ifdef NULL_PLUGIN
-
-namespace proxy_wasm {
-namespace null_plugin {
-namespace scaffold {
-
-PROXY_WASM_NULL_PLUGIN_REGISTRY
-
-#endif
-
 static RegisterContextFactory register_Scaffold(
     CONTEXT_FACTORY(PluginContext), ROOT_FACTORY(PluginRootContext));
 
 bool PluginRootContext::onConfigure(size_t) { return true; }
-
-#ifdef NULL_PLUGIN
-
-}  // scaffold
-}  // namespace null_plugin
-}  // namespace proxy_wasm
-
-#endif

--- a/extensions/scaffold/plugin.h
+++ b/extensions/scaffold/plugin.h
@@ -1,16 +1,4 @@
-#ifndef NULL_PLUGIN
-
 #include "proxy_wasm_intrinsics.h"
-
-#else
-
-#include "include/proxy-wasm/null_plugin.h"
-
-namespace proxy_wasm {
-namespace null_plugin {
-namespace scaffold {
-
-#endif
 
 // PluginRootContext is the root context for all streams processed by the
 // thread. It has the same lifetime as the VM and acts as target for
@@ -33,11 +21,3 @@ class PluginContext : public Context {
     return dynamic_cast<PluginRootContext*>(this->root());
   }
 };
-
-#ifdef NULL_PLUGIN
-
-}  // namespace scaffold
-}  // namespace null_plugin
-}  // namespace proxy_wasm
-
-#endif


### PR DESCRIPTION
Most user probably won't care about null_plugin mode when getting started and it is a distraction. Usage of null_plugin mode is only for unit testing and is covered in this guide: https://github.com/istio-ecosystem/wasm-extensions/pull/30.

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>