### PR TITLE
Add dep sha dump script.

### DIFF
--- a/doc/write-a-wasm-extension-with-cpp.md
+++ b/doc/write-a-wasm-extension-with-cpp.md
@@ -29,7 +29,7 @@ load("@proxy_wasm_cpp_sdk//bazel/dep:deps_extra.bzl", "wasm_dependencies_extra")
 wasm_dependencies_extra()
 ```
 
-Currently, it is recommanded to update SHA of Wasm C++ SDK and build your extension following Istio releases. See [step 7](#step-7-maintain-your-extension-along-with-istio-releases) for more details on extension maintainance. (TODO: https://github.com/istio-ecosystem/wasm-extensions/issues/27) You can rename the workspace to anything relevent to your extension. Other dependencies could also be imported as needed, such as JSON library, base64 library, etc. See the [top level `WORKSPACE` file](../WORKSPACE) for examples.
+Currently, it is recommanded to update SHA of Wasm C++ SDK and build your extension following Istio releases. See [step 7](#step-7-maintain-your-extension-along-with-istio-releases) for more details on extension maintainance. To get SHA and checksum of various dependencies, you can run [`get-dep.sh`](../scripts/get-dep.sh). For example, to get SHA of 1.8 dependencies, run `./scripts/get-dep.sh -r 1.8`. You can rename the workspace to anything relevent to your extension. Other dependencies could also be imported as needed, such as JSON library, base64 library, etc. See the [top level `WORKSPACE` file](../WORKSPACE) for examples.
 
 ## Step 2: Set up extension scaffold
 ---

--- a/scripts/get-dep.sh
+++ b/scripts/get-dep.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -e
+
+# Prints proxy-wasm-cpp-sdk, proxy-wasm-cpp-host, and istio-proxy SHA based on the given branch
+function usage() {
+  echo "$0
+    -r the release branch that this script should look at, e.g. 1.8, master."
+  exit 1
+}
+
+RELEASE=""
+
+while getopts r: arg ; do
+  case "${arg}" in
+    r) RELEASE="${OPTARG}";;
+    *) usage;;
+  esac
+done
+
+if [[ ${RELEASE} == "" ]]; then
+    echo "release branch has to be provided. e.g. get-dep.sh -r 1.8"
+    exit 1
+fi
+
+echo "Fetching deps SHA..."
+
+ENVOY_TMP_DIR=$(mktemp -d -t envoy-XXXXXXXXXX)
+trap "rm -rf ${ENVOY_TMP_DIR}" EXIT
+
+pushd ${ENVOY_TMP_DIR} > /dev/null
+if [[ ${RELEASE} == "master" ]]; then
+  git clone --depth=1 --branch master https://github.com/envoyproxy/envoy 2> /dev/null
+else
+  git clone --depth=1 --branch release-${RELEASE} https://github.com/istio/envoy 2> /dev/null
+fi
+cd envoy
+
+NEW_SDK_SHA=$(bazel query //external:proxy_wasm_cpp_sdk --output=build 2> /dev/null | grep -Pom1 "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/\K[a-zA-Z0-9]{40}")
+NEW_SDK_SHA256=$(bazel query //external:proxy_wasm_cpp_sdk --output=build 2> /dev/null | grep -Pom1 "sha256 = \"\K[a-zA-Z0-9]{64}")
+NEW_HOST_SHA=$(bazel query //external:proxy_wasm_cpp_host --output=build 2> /dev/null | grep -Pom1 "https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/\K[a-zA-Z0-9]{40}")
+NEW_HOST_SHA256=$(bazel query //external:proxy_wasm_cpp_host --output=build 2> /dev/null | grep -Pom1 "sha256 = \"\K[a-zA-Z0-9]{64}")
+
+popd > /dev/null
+
+# Istio proxy SHA update
+ISTIO_PROXY_TMP_DIR=$(mktemp -d -t proxy-XXXXXXXXXX)
+trap "rm -rf ${ISTIO_PROXY_TMP_DIR}" EXIT
+
+pushd ${ISTIO_PROXY_TMP_DIR} > /dev/null
+
+if [[ ${RELEASE} == "master" ]]; then
+  git clone --depth=1 --branch master https://github.com/istio/proxy 2> /dev/null
+else
+  git clone --depth=1 --branch release-${RELEASE} https://github.com/istio/proxy 2> /dev/null
+fi
+cd proxy
+
+NEW_PROXY_SHA=$(git rev-parse HEAD)
+NEW_PROXY_SHA256=$(wget https://github.com/istio/proxy/archive/${NEW_PROXY_SHA}.tar.gz 2> /dev/null && sha256sum ${NEW_PROXY_SHA}.tar.gz | grep -Pom1 "\K[a-zA-Z0-9]{64}") > /dev/null
+
+popd > /dev/null
+
+echo "At Istio ${RELEASE}:"
+echo "proxy Wasm cpp sdk SHA ${NEW_SDK_SHA} Checksum: ${NEW_SDK_SHA256}"
+echo "Proxy Wasm cpp host SHA ${NEW_HOST_SHA} Checksum: ${NEW_HOST_SHA256}"
+echo "Istio proxy SHA ${NEW_PROXY_SHA} Checksum: ${NEW_PROXY_SHA256}"


### PR DESCRIPTION
Fixes https://github.com/istio-ecosystem/wasm-extensions/issues/27. Example output:
```console
bianpengyuan_google_com@work:~/wasm-extensions$ ./scripts/get-dep.sh -r master
Fetching deps SHA...
At Istio master:
proxy Wasm cpp sdk SHA 956f0d500c380cc1656a2d861b7ee12c2515a664 Checksum: b97e3e716b1f38dc601487aa0bde72490bbc82b8f3ad73f1f3e69733984955df
Proxy Wasm cpp host SHA 15827110ac35fdac9abdb6b05d04ee7ee2044dae Checksum: 77a2671205eb0973bee375a1bee4099edef991350433981f6e3508780318117d
Istio proxy SHA 6c2c111bd06d8f148d02504448ca7b253a1c2c8e Checksum: 847c37901bcd66201b4a25662f0f73451708eabd5211fd6fe33828debd48ca28
```

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>