### PR TITLE
Add a script to update example plugin and walkthrough guide.

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -51,13 +51,17 @@ jobs:
             mkdir -p wasm-extensions/${EXTENSION_NAME//_/-}
             cp bazel-bin/${WASM_PATH} wasm-extensions/${EXTENSION_NAME//_/-}/${GITHUB_SHA}.wasm
 
-            # also push binary with more readable name, so that it could be easily used in configuration and documentation.
-            # for example, the following command is going to push 'basic_auth/<SHA>.wasm' to 'basic_auth/1.7-2020-11-18-08-09-10' and 'basic_auth/1.7-latest'.
-            cp wasm-extensions/${EXTENSION_NAME//_/-}/${GITHUB_SHA}.wasm wasm-extensions/${EXTENSION_NAME//_/-}/${VERSION}-$(date +"%Y-%m-%d-%H-%M-%S").wasm
-            cp wasm-extensions/${EXTENSION_NAME//_/-}/${GITHUB_SHA}.wasm wasm-extensions/${EXTENSION_NAME//_/-}/${VERSION}-latest.wasm 
-
             # TODO: add precompiled module
           done
+
+      - name: Build Example
+        run: |
+          set -eux
+          pushd example
+          bazel build //:example.wasm
+          popd
+          mkdir -p wasm-extensions/example
+          cp example/bazel-bin/example.wasm wasm-extensions/example/${GITHUB_SHA}.wasm
 
       - name: Upload Modules
         uses: GoogleCloudPlatform/github-actions/upload-cloud-storage@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,13 @@ jobs:
         run: |
           COMMIT=$(git rev-list -n 1 ${{ github.ref }})
           gsutil cp gs://istio-ecosystem/wasm-extensions/basic-auth/${COMMIT}.wasm basic-auth.wasm
+          gsutil cp gs://istio-ecosystem/wasm-extensions/example/${COMMIT}.wasm example.wasm
           # Also prepare an Wasm extension dir for GCS uploading.
           mkdir -p wasm-extensions/basic-auth
+          mkdir -p wasm-extensions/example
           GITHUB_TAG_REF=${{ github.ref }}
           cp basic-auth.wasm wasm-extensions/basic-auth/${GITHUB_TAG_REF##*/}.wasm
+          cp example.wasm wasm-extensions/example/${GITHUB_TAG_REF##*/}.wasm
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -34,7 +37,7 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
+      - name: Upload Basic Auth Release Asset
         id: upload-release-asset 
         uses: actions/upload-release-asset@v1
         env:
@@ -43,6 +46,16 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }} 
           asset_path: ./basic-auth.wasm
           asset_name: basic-auth.wasm
+          asset_content_type: application/wasm
+      - name: Upload Example Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: ./example.wasm
+          asset_name: example.wasm
           asset_content_type: application/wasm
       - name: Upload Modules
         uses: GoogleCloudPlatform/github-actions/upload-cloud-storage@master

--- a/doc/write-a-wasm-extension-with-cpp.md
+++ b/doc/write-a-wasm-extension-with-cpp.md
@@ -10,8 +10,8 @@ Create a folder for the extension code. Under the folder, craete a `WORKSPACE` f
 
 ```python
 # Pulls proxy wasm cpp SDK with a specific SHA
-PROXY_WASM_CPP_SDK_SHA = "7afb39d868a973caa6216a535c24e37fb666b6f3"
-PROXY_WASM_CPP_SDK_SHA256 = "213d0b441bcc3df2c87933b24a593b5fd482fa8f4db158b707c60005b9e70040"
+PROXY_WASM_CPP_SDK_SHA = "f5ecda129d1e45de36cb7898641ac225a50ce7f0"
+PROXY_WASM_CPP_SDK_SHA256 = "0f675ef5c4f8fdcf2fce8152868c6c6fd33251a0deb4a8fc1ef721f9ed387dbc"
 
 http_archive(
     name = "proxy_wasm_cpp_sdk",

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -3,8 +3,8 @@ workspace(name = "example_extension")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Pulls proxy wasm cpp SDK with a specific SHA
-PROXY_WASM_CPP_SDK_SHA = "7afb39d868a973caa6216a535c24e37fb666b6f3"
-PROXY_WASM_CPP_SDK_SHA256 = "213d0b441bcc3df2c87933b24a593b5fd482fa8f4db158b707c60005b9e70040"
+PROXY_WASM_CPP_SDK_SHA = "f5ecda129d1e45de36cb7898641ac225a50ce7f0"
+PROXY_WASM_CPP_SDK_SHA256 = "0f675ef5c4f8fdcf2fce8152868c6c6fd33251a0deb4a8fc1ef721f9ed387dbc"
 
 http_archive(
     name = "proxy_wasm_cpp_sdk",

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -3,11 +3,14 @@ workspace(name = "example_extension")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Pulls proxy wasm cpp SDK with a specific SHA
+PROXY_WASM_CPP_SDK_SHA = "7afb39d868a973caa6216a535c24e37fb666b6f3"
+PROXY_WASM_CPP_SDK_SHA256 = "213d0b441bcc3df2c87933b24a593b5fd482fa8f4db158b707c60005b9e70040"
+
 http_archive(
     name = "proxy_wasm_cpp_sdk",
-    sha256 = "0f675ef5c4f8fdcf2fce8152868c6c6fd33251a0deb4a8fc1ef721f9ed387dbc",
-    strip_prefix = "proxy-wasm-cpp-sdk-f5ecda129d1e45de36cb7898641ac225a50ce7f0",
-    url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/f5ecda129d1e45de36cb7898641ac225a50ce7f0.tar.gz",
+    sha256 = PROXY_WASM_CPP_SDK_SHA256,
+    strip_prefix = "proxy-wasm-cpp-sdk-" + PROXY_WASM_CPP_SDK_SHA,
+    url = "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/" + PROXY_WASM_CPP_SDK_SHA + ".tar.gz",
 )
 
 load("@proxy_wasm_cpp_sdk//bazel/dep:deps.bzl", "wasm_dependencies")

--- a/scripts/update-guide.sh
+++ b/scripts/update-guide.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -eu
+
+# Update example extension and various guide with SDK SHA the given release.
+# The files touched by this script are:
+# * Example extension workspace file `example/WORKSPACE`, which has proxy wasm cpp sdk SHA and checksum.
+# * Example extension config example file `example/config/example-filter.yaml`, which has the module download link and checksum.
+# * Example extension config integration test `example/test/example_test.go`, which has the proxy version to download for integration testing.
+# * Wasm extension C++ Walkthrough `doc/write-a-wasm-extension-with-cpp.md`, which has the proxy wasm cpp sdk SHA and checksum.
+# * Wasm extension integration test guide `doc/write-integration-test.md`, which has the proxy version to download for integration testing.
+# * (Not yet added) Basic auth filter config example file.
+function usage() {
+  echo "$0
+    -r the release branch that this script should look at, e.g. 1.8, master."
+  exit 1
+}
+
+RELEASE=""
+
+while getopts r: arg ; do
+  case "${arg}" in
+    r) RELEASE="${OPTARG}";;
+    *) usage;;
+  esac
+done
+
+if [[ ${RELEASE} == "" ]]; then
+    echo "release branch has to be provided. e.g. update-guide.sh -r 1.8"
+    exit 1
+fi
+
+# Clone istio-envoy repo, get and update proxy Wasm sdk and host SHA
+ENVOY_TMP_DIR=$(mktemp -d -t envoy-XXXXXXXXXX)
+trap "rm -rf ${ENVOY_TMP_DIR}" EXIT
+
+pushd ${ENVOY_TMP_DIR}
+if [[ ${RELEASE} == "master" ]]; then
+  git clone --depth=1 --branch master https://github.com/envoyproxy/envoy
+else
+  git clone --depth=1 --branch release-${RELEASE} https://github.com/istio/envoy
+fi
+cd envoy
+
+NEW_SDK_SHA=$(bazel query //external:proxy_wasm_cpp_sdk --output=build | grep -Pom1 "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/\K[a-zA-Z0-9]{40}")
+NEW_SDK_SHA256=$(bazel query //external:proxy_wasm_cpp_sdk --output=build | grep -Pom1 "sha256 = \"\K[a-zA-Z0-9]{64}")
+
+popd
+
+# Update example WORKSPACE, integration test proxy version
+sed -e "s|PROXY_WASM_CPP_SDK_SHA = .*|PROXY_WASM_CPP_SDK_SHA = \"${NEW_SDK_SHA}\"|" -i example/WORKSPACE
+sed -e "s|PROXY_WASM_CPP_SDK_SHA256 = .*|PROXY_WASM_CPP_SDK_SHA256 = \"${NEW_SDK_SHA256}\"|" -i example/WORKSPACE
+sed -e "s|DownloadVersion:.*|DownloadVersion: \"${RELEASE}\",|" -i example/test/example_test.go
+
+# Update example config with wasm file of the new version.
+EXAMPLE_WASM_MODULE_URL="https://storage.googleapis.com.*|uri: https://storage.googleapis.com/istio-ecosystem/wasm-extensions/example/${RELEASE}.0.wasm"
+EXAMPLE_MODULE_CHECKSUM=$(wget ${EXAMPLE_WASM_MODULE_URL} && sha256sum ${RELEASE}.0.wasm | cut -d' ' -f 1)
+sed - e "s|uri: ${EXAMPLE_WASM_MODULE_URL}|" -i example/config/example-filter.yaml
+sed -e "s|sha256: .*|sha256: ${EXAMPLE_MODULE_CHECKSUM}" -i example/config/example-filter.yaml
+
+# Update guide doc
+sed -e "s|PROXY_WASM_CPP_SDK_SHA = .*|PROXY_WASM_CPP_SDK_SHA = \"${NEW_SDK_SHA}\"|" -i doc/write-a-wasm-extension-with-cpp.md
+sed -e "s|PROXY_WASM_CPP_SDK_SHA256 = .*|PROXY_WASM_CPP_SDK_SHA256 = \"${NEW_SDK_SHA256}\"|" -i doc/write-a-wasm-extension-with-cpp.md
+sed -e "s|DownloadVersion:.*|DownloadVersion: \"${RELEASE}\",|" -i doc/write-integration-test.md


### PR DESCRIPTION
Also include several other changes:
* Push example wasm module like basic auth wasm module, so that guide could also follow istio version.
* Remove EnvoyFilter in the walkthrough guide and only point to the example config file as the source of truth.

This is in prep of the release process doc: https://github.com/istio-ecosystem/wasm-extensions/compare/master...bianpengyuan:doc/release-process?expand=1

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>