### PR TITLE
[release-1.9] Add authenticate header into basic auth response. (#48)

### DIFF
--- a/extensions/basic_auth/README.md
+++ b/extensions/basic_auth/README.md
@@ -78,6 +78,10 @@ The following proto message describes the schema of basic auth filter configurat
 message PluginConfig {
   // Specifies a list of basic auth rules
   repeated BasicAuth basic_auth_rules = 1;
+
+  // Protection space of basic auth: https://tools.ietf.org/html/rfc7617#section-2.
+  // If not provided, the default value is `istio`.
+  string realm = 2;
 }
 
 // BasicAuth defines restriction rules based on three elements.

--- a/extensions/basic_auth/plugin.h
+++ b/extensions/basic_auth/plugin.h
@@ -68,6 +68,7 @@ class PluginRootContext : public RootContext {
   std::unordered_map<std::string,
                      std::vector<PluginRootContext::BasicAuthConfigRule>>
       basic_auth_configuration_;
+  std::string realm_ = "istio";
   FilterHeadersStatus credentialsCheck(
       const PluginRootContext::BasicAuthConfigRule&, std::string_view);
 };

--- a/test/basicauth/basicauth_test.go
+++ b/test/basicauth/basicauth_test.go
@@ -14,55 +14,72 @@ import (
 )
 
 var TestCases = []struct {
-	Name           string
-	Method         string
-	Path           string
-	RequestHeaders map[string]string
-	ResponseCode   int
+	Name            string
+	Method          string
+	Path            string
+	Realm           string
+	RequestHeaders  map[string]string
+	ResponseHeaders map[string]string
+	ResponseCode    int
 }{
 	{
-		Name:           "CorrectCredentials",
-		Method:         "GET",
-		Path:           "/api",
-		RequestHeaders: map[string]string{"Authorization": "Basic b2s6dGVzdA=="},
-		ResponseCode:   200,
+		Name:            "CorrectCredentials",
+		Method:          "GET",
+		Path:            "/api",
+		RequestHeaders:  map[string]string{"Authorization": "Basic b2s6dGVzdA=="},
+		ResponseHeaders: map[string]string{},
+		ResponseCode:    200,
 	},
 	{
-		Name:           "IncorrectCredentials",
-		Method:         "POST",
-		Path:           "/api/reviews/pay",
-		RequestHeaders: map[string]string{"Authorization": "Basic AtRtaW46YWRtaW4="},
-		ResponseCode:   401,
+		Name:            "IncorrectCredentials",
+		Method:          "POST",
+		Path:            "/api/reviews/pay",
+		RequestHeaders:  map[string]string{"Authorization": "Basic AtRtaW46YWRtaW4="},
+		ResponseHeaders: map[string]string{"WWW-Authenticate": "Basic realm=istio"},
+		ResponseCode:    401,
 	},
 	{
-		Name:           "Base64Credentials",
-		Method:         "POST",
-		Path:           "/api/reviews/pay",
-		RequestHeaders: map[string]string{"Authorization": "Basic YWRtaW4zOmFkbWluMw=="},
-		ResponseCode:   200,
+		Name:            "Base64Credentials",
+		Method:          "POST",
+		Path:            "/api/reviews/pay",
+		RequestHeaders:  map[string]string{"Authorization": "Basic YWRtaW4zOmFkbWluMw=="},
+		ResponseHeaders: map[string]string{},
+		ResponseCode:    200,
 	},
 	{
-		Name:         "MissingCredentials",
-		Method:       "GET",
-		Path:         "/api/reviews/pay",
-		ResponseCode: 401,
+		Name:            "MissingCredentials",
+		Method:          "GET",
+		Path:            "/api/reviews/pay",
+		ResponseHeaders: map[string]string{"WWW-Authenticate": "Basic realm=istio"},
+		ResponseCode:    401,
 	},
 	{
-		Name:         "NoPathMatch",
-		Path:         "/secret",
-		ResponseCode: 200,
+		Name:            "NoPathMatch",
+		Path:            "/secret",
+		ResponseHeaders: map[string]string{},
+		ResponseCode:    200,
 	},
 	{
-		Name:         "NoMethodMatch",
-		Method:       "DELETE",
-		Path:         "/api/reviews/pay",
-		ResponseCode: 200,
+		Name:            "NoMethodMatch",
+		Method:          "DELETE",
+		Path:            "/api/reviews/pay",
+		ResponseHeaders: map[string]string{},
+		ResponseCode:    200,
 	},
 	{
-		Name:         "NoConfigurationCredentialsProvided",
-		Method:       "POST",
-		Path:         "/api/reviews/pay",
-		ResponseCode: 401,
+		Name:            "NoConfigurationCredentialsProvided",
+		Method:          "POST",
+		Path:            "/api/reviews/pay",
+		ResponseHeaders: map[string]string{"WWW-Authenticate": "Basic realm=istio"},
+		ResponseCode:    401,
+	},
+	{
+		Name:            "Realm",
+		Method:          "POST",
+		Path:            "/api/reviews/pay",
+		Realm:           "test",
+		ResponseHeaders: map[string]string{"WWW-Authenticate": "Basic realm=test"},
+		ResponseCode:    401,
 	},
 }
 
@@ -72,9 +89,12 @@ func TestBasicAuth(t *testing.T) {
 			params := driver.NewTestParams(t, map[string]string{
 				"BasicAuthWasmFile": filepath.Join(env.GetBazelBinOrDie(), "extensions/basic_auth/basic_auth.wasm"),
 			}, test.ExtensionE2ETests)
+			if testCase.Realm != "" {
+				params.Vars["Realm"] = testCase.Realm
+			}
 			params.Vars["ServerHTTPFilters"] = params.LoadTestData("test/basicauth/testdata/server_filter.yaml.tmpl")
 			if err := (&driver.Scenario{
-				[]driver.Step{
+				Steps: []driver.Step{
 					&driver.XDS{},
 					&driver.Update{
 						Node: "server", Version: "0", Listeners: []string{string(testdata.MustAsset("listener/server.yaml.tmpl"))},
@@ -85,11 +105,12 @@ func TestBasicAuth(t *testing.T) {
 					},
 					&driver.Sleep{Duration: 1 * time.Second},
 					&driver.HTTPCall{
-						Port:           params.Ports.ServerPort,
-						Method:         testCase.Method,
-						Path:           testCase.Path,
-						RequestHeaders: testCase.RequestHeaders,
-						ResponseCode:   testCase.ResponseCode,
+						Port:            params.Ports.ServerPort,
+						Method:          testCase.Method,
+						Path:            testCase.Path,
+						RequestHeaders:  testCase.RequestHeaders,
+						ResponseHeaders: testCase.ResponseHeaders,
+						ResponseCode:    testCase.ResponseCode,
 					},
 				},
 			}).Run(params); err != nil {

--- a/test/basicauth/testdata/server_filter.yaml.tmpl
+++ b/test/basicauth/testdata/server_filter.yaml.tmpl
@@ -23,5 +23,10 @@
                   "request_methods":[ "GET", "POST" ],
                   "credentials":[ "admin:admin", "admin2:admin2", "ok:test", "YWRtaW4zOmFkbWluMw==" ] 
                 }
-              ]
+              ],
+              {{- if .Vars.Realm }}
+              "realm": "{{ .Vars.Realm }}"
+              {{- else }}
+              "realm": "istio"
+              {{- end }}
             }


### PR DESCRIPTION
* Add authenticate header into basic auth response.

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>

* Add actually logic.

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>

* format

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>

* update readme

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>